### PR TITLE
Some revisions to pg_stat_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Targets for near future development:
 
 Future views:
 
-* _pg\_stat\_relations_:  Combined table and index view.
+* _pg\_stat\_blocks_:  Combined table and index view.
 
 Eventually _pg\_goggles_ may expand to where it's packaged in an extension or some other form for easier testing and use.
 


### PR DESCRIPTION
- field renames to be more in-line with system catalogs
- rename a couple missed blks -> bytes field names
- rework the view to actually *use* the CTE field
- add toast_index_* stats as well
- remove the relation size filter